### PR TITLE
[MCKIN-10516][BB-3915] Reduce drag delay on mobile 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 Drag and Drop XBlock changelog
 ==============================
 
+Version 2.3.7 (2022-02-20)
+---------------------------
+
+* Reduce drag delay on mobile devices.
+
 Version 2.3.6 (2021-08-11)
 ---------------------------
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 Drag and Drop XBlock changelog
 ==============================
 
+Version 2.3.6 (2021-08-11)
+---------------------------
+
+* Add Portuguese translations.
+
 Version 2.3.5 (2021-03-09)
 ---------------------------
 

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -762,7 +762,7 @@ function DragAndDropBlock(runtime, element, configuration) {
     // Number of miliseconds the user has to keep their finger on the item
     // without moving for drag to begin.
     // This allows user to scroll the container without accidentally dragging the items.
-    var TOUCH_DRAG_DELAY = 500;
+    var TOUCH_DRAG_DELAY = 250;
 
     // Keyboard accessibility
     var ESC = 27;

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.3.6',
+    version='2.3.7',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
We received feedback that moving items is not intuitive on touch devices. We opened 3 PoC PRs for improving it. The #208 and #209 are rejected approaches.

This increases the sensitivity of dragging items (reduced the dragging delay). This way it will be less unusual for user to wait after holding his finger on the item:
![increase_sensitivity](https://user-images.githubusercontent.com/3189670/57171932-dba87980-6e19-11e9-968a-7f6dccf0b4bc.gif)

## Testing instructions
1. Install this XBlock.
2. Create `Problem -> Advanced -> Drag and Drop` unit.
3. Test this on a mobile device. I've tested this with Firefox Nightly 210331.