### PR TITLE
Changes D&Dv2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,15 @@
 Drag and Drop XBlock changelog
 ==============================
 
+Version 2.3.8 (2022-04-12)
+---------------------------
+
+* Add item option to remove padding from images dropped on a zone.
+* Add option to show zone border when dragging an item.
+* Hides text when a draggable item is placed in a target zone and frontend wait for LMS response, this is done since the size of the item increases when the spinner is visible.
+* Change containers and css classes to match those from edx-platform. The problem div now contains the drag container, buttons and feedback, css classes from submit button; submit answer and action buttons were also changed.
+* Improve feedback styles, now only icons shows color related with feedback and text color remains the same also each feedback line doesn't show borders.
+
 Unreleased
 ---------------------------
 * Replaced `Travis` with `GitHub CI`.

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -378,6 +378,7 @@ class DragAndDropBlock(
             "url_name": getattr(self, 'url_name', ''),
             "display_zone_labels": self.data.get('displayLabels', False),
             "display_zone_borders": self.data.get('displayBorders', False),
+            "display_zone_borders_dragging": self.data.get('displayBordersDragging', False),
             "items": items_without_answers(),
             "title": self.display_name,
             "show_title": self.show_title,

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -1,6 +1,5 @@
 .xblock--drag-and-drop {
     width: auto;
-    max-width: 770px;
     margin: 0;
     padding: 0;
     position: relative;

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -173,6 +173,23 @@
     word-wrap: break-word;
 }
 
+.xblock--drag-and-drop .drag-container .option .spinner-wrapper {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    opacity: 0.6;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.xblock--drag-and-drop .drag-container .option .spinner-wrapper + .item-content{
+    visibility: hidden;
+}
+
 /* Placed option */
 .xblock--drag-and-drop .drag-container .target .option {
     position: absolute;

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -348,23 +348,7 @@
 
 .xblock--drag-and-drop .feedback p {
     margin: 2px 0;
-    padding: 0.5em;
-    border: 2px solid #999;
-}
-
-.xblock--drag-and-drop .feedback p.correct {
-    color: #166e36;
-    border: 2px solid #166e36;
-}
-
-.xblock--drag-and-drop .feedback p.partial {
-    color: #166e36;
-    border: 2px solid #166e36;
-}
-
-.xblock--drag-and-drop .feedback p.incorrect {
-    color: #b20610;
-    border: 2px solid #b20610;
+    padding: 0.25em;
 }
 
 
@@ -389,6 +373,7 @@
 .rtl .xblock--drag-and-drop .feedback p.correct:after {
     content: "\f00c";
     font-family: FontAwesome;
+    color: #166e36;
 }
 
 .ltr .xblock--drag-and-drop .feedback p.correct:before {
@@ -405,6 +390,7 @@
 .rtl .xblock--drag-and-drop .feedback p.partial:after {
     content: "\f069";
     font-family: FontAwesome;
+    color: #166e36;
 }
 
 .ltr .xblock--drag-and-drop .feedback p.partial:before {
@@ -421,6 +407,7 @@
 .rtl .xblock--drag-and-drop .feedback p.incorrect:after {
     content: "\f00d";
     font-family: FontAwesome;
+    color: #b20610;
 }
 
 .ltr .xblock--drag-and-drop .feedback p.incorrect:before {

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -149,6 +149,10 @@
     width: 100%;  /* If the image is smaller than the specified width, make it larger */
 }
 
+.xblock--drag-and-drop .drag-container .option.option-with-image {
+    line-height: 0;  /* Eliminates extra space */
+}
+
 .xblock--drag-and-drop .drag-container .option.option-with-image .spinner-wrapper {
     position: absolute;
     float: none;

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -609,7 +609,6 @@
     -moz-transition: color 0.125s ease-in-out 0s, border-color 0.125s ease-in-out 0s, background 0.125s ease-in-out 0s, box-shadow 0.125s ease-in-out 0s;
     transition: color 0.125s ease-in-out 0s, border-color 0.125s ease-in-out 0s, background 0.125s ease-in-out 0s, box-shadow 0.125s ease-in-out 0s;
     border-radius: 3px;
-    border: 1px solid #0079bc;
     padding: 0.625em 1.25em;
     font-size: 1em;
 }
@@ -617,13 +616,6 @@
 .xblock--drag-and-drop .btn-default {
     border-color: transparent;
     background: transparent;
-    color: #0074b4
-}
-
-.xblock--drag-and-drop .btn-brand {
-  border-color: #0075b4;
-  background: white;
-  color: #0075b4;
 }
 
 .xblock--drag-and-drop .btn-small {
@@ -646,137 +638,109 @@
     color: #0074b4
 }
 
-.xblock--drag-and-drop .btn-default:active,
-.xblock--drag-and-drop .btn-default.is-pressed,
-.xblock--drag-and-drop .btn-default.is-active {
-    border-color: #0074b4;
-    color: #0074b4
-}
-
-.xblock--drag-and-drop .btn-default:disabled,
-.xblock--drag-and-drop .btn-default.is-disabled {
-    color: #6b6969
-}
-
-.xblock--drag-and-drop .btn-brand {
-    border-color: #0074b4;
-    background: #0074b4;
-    color: #fcfcfc
-}
-
 .xblock--drag-and-drop .btn-brand:hover,
 .xblock--drag-and-drop .btn-brand.is-hovered,
-.xblock--drag-and-drop .btn-brand:focus,
 .xblock--drag-and-drop .btn-brand.is-focused {
-    border-color: #008bd8;
-    background-color: #008bd8;
-    color: #fcfcfc
+    background-color: #065683;
 }
 
-.xblock--drag-and-drop .btn-brand:active,
 .xblock--drag-and-drop .btn-brand.is-pressed,
 .xblock--drag-and-drop .btn-brand.is-active {
     border-color: #0074b4;
     background: #0074b4
 }
 
-.xblock--drag-and-drop .btn-brand:disabled,
-.xblock--drag-and-drop .btn-brand.is-disabled {
-    border-color: #d2d0d0;
-    background: #f2f3f3;
-    color: #676666
-}
-
-
 /*** ACTIONS TOOLBAR ***/
 
-.xblock--drag-and-drop .actions-toolbar {
+.xblock--drag-and-drop .action {
     min-height: 3.75em;
     width: auto;
     position: relative;
 }
 
-.xblock--drag-and-drop .actions-toolbar .action-toolbar-item {
+.xblock--drag-and-drop .action .problem-action-buttons-wrapper,
+.xblock--drag-and-drop .action .submit-attempt-container {
     display: inline-block;
     margin: 10px 0;
 }
 
-.xblock--drag-and-drop .attempts-used {
+.xblock--drag-and-drop .submission-feedback {
     font-size: 0.875em;
     color: #666;
+    display: inline-block;
 }
 
-.ltr .xblock--drag-and-drop .attempts-used {
+.ltr .xblock--drag-and-drop .submission-feedback {
     margin-left: 0.675em;
 }
 
-.rtl .xblock--drag-and-drop .attempts-used {
+.rtl .xblock--drag-and-drop .submission-feedback {
     margin-right: 0.675em;
 }
 
-.xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
+.xblock--drag-and-drop .action .problem-action-buttons-wrapper {
     display: block;
 }
 
-.ltr .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
+.ltr .xblock--drag-and-drop .action .problem-action-buttons-wrapper {
     text-align: left;
 }
 
-.rtl .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
+.rtl .xblock--drag-and-drop .action .problem-action-buttons-wrapper {
     text-align: right;
 }
 
 @media (min-width: 768px) {
-    .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
+    .xblock--drag-and-drop .action .problem-action-buttons-wrapper {
         margin: 0;
     }
 
-    .ltr .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
+    .ltr .xblock--drag-and-drop .action .problem-action-buttons-wrapper {
         float: right;
         padding-right: -5px;
         padding-top: 5px;
     }
 
-    .rtl .xblock--drag-and-drop .actions-toolbar .action-toolbar-item.sidebar-buttons {
+    .rtl .xblock--drag-and-drop .action .problem-action-buttons-wrapper {
         float: left;
         padding-left: -5px;
     }
 }
 
-.xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper {
+.xblock--drag-and-drop .problem-action-buttons-wrapper .problem-action-button-wrapper {
     border-collapse: collapse;
     padding: 0 5px;
     display: inline-block;
     height: 100%;
 }
 
-.ltr .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper {
+.ltr .xblock--drag-and-drop .problem-action-buttons-wrapper .problem-action-button-wrapper {
     border-right: 1px solid #ddd;
 }
 
-.rtl .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper {
+.rtl .xblock--drag-and-drop .problem-action-buttons-wrapper .problem-action-button-wrapper {
     border-left: 1px solid #ddd;
 }
 
-.ltr .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper:first-child {
+.ltr .xblock--drag-and-drop .problem-action-buttons-wrapper .problem-action-button-wrapper:first-child {
     padding-left: 0;
 }
 
-.rtl .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper:first-child {
+.rtl .xblock--drag-and-drop .problem-action-buttons-wrapper .problem-action-button-wrapper:first-child {
     padding-right: 0;
 }
 
-.ltr .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper:last-child {
+.ltr .xblock--drag-and-drop .problem-action-buttons-wrapper .problem-action-button-wrapper:last-child {
     border-right: none;
     padding-right: 0;
 }
 
-.rtl .xblock--drag-and-drop .sidebar-buttons .sidebar-button-wrapper:last-child {
+.rtl .xblock--drag-and-drop .problem-action-buttons-wrapper .problem-action-button-wrapper:last-child {
     border-left: none;
     padding-left: 0;
 }
 
-.xblock--drag-and-drop .sidebar-buttons .btn-brand {
+.xblock--drag-and-drop .problem-action-buttons-wrapper .btn-brand {
     display: inline-block;
     padding: 3px 5px;
 }

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -337,6 +337,17 @@
     border: 1px dotted #565656;
 }
 
+
+/* Display a border while dragging an item over the item bank. */
+.xblock--drag-and-drop .item-bank.zone-border {
+    border: 1px solid #000000;
+}
+
+/* Display a border while dragging an item over a zone. */
+.xblock--drag-and-drop .zone.zone-border {
+    border: 4px solid #000000;
+}
+
 /* Focused zone */
 .xblock--drag-and-drop .item-bank:focus,
 .xblock--drag-and-drop .zone:focus {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1440,7 +1440,7 @@ function DragAndDropBlock(runtime, element, configuration) {
         var getTargetZone = function(evt) {
             var $zone = null;
             var x, y;
-            if (evt.type === 'mouseup') {
+            if (evt.type === 'mouseup' || evt.type === 'mousemove') {
                 x = evt.clientX;
                 y = evt.clientY;
             } else {
@@ -1522,8 +1522,22 @@ function DragAndDropBlock(runtime, element, configuration) {
             };
 
             var raf_id = null;
+            var $last_target_zone = null;
             var onDragMove = function(evt) {
                 evt.preventDefault();
+                var $zone = getTargetZone(evt);
+                if (configuration.display_zone_borders_dragging) {
+                    if ($zone) {
+                        if ($last_target_zone && $zone.attr('id') !== $last_target_zone.attr('id')) {
+                            $last_target_zone.removeClass('zone-border');
+                        }
+                        $zone.addClass('zone-border');
+                        $last_target_zone = $zone;
+                    } else if ($last_target_zone) {
+                        $last_target_zone.removeClass('zone-border');
+                        $last_target_zone = null;
+                    }
+                }
                 if (raf_id) {
                     cancelAnimationFrame(raf_id);
                 }
@@ -1603,6 +1617,10 @@ function DragAndDropBlock(runtime, element, configuration) {
                     releaseGrabbedItems();
                 } else {
                     revertDrag();
+                }
+                if (configuration.display_zone_borders_dragging && $last_target_zone) {
+                    $last_target_zone.removeClass('zone-border');
+                    $last_target_zone = null;
                 }
             };
 
@@ -1954,6 +1972,7 @@ function DragAndDropBlock(runtime, element, configuration) {
             target_img_description: configuration.target_img_description,
             display_zone_labels: configuration.display_zone_labels,
             display_zone_borders: configuration.display_zone_borders,
+            display_zone_borders_dragging: configuration.display_zone_borders_dragging,
             zones: configuration.zones,
             items: items,
             // state - parts that can change:

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -114,15 +114,20 @@ function DragAndDropTemplates(configuration) {
         if (item.is_placed) {
             var maxWidth = (item.widthPercent || 30) / 100;
             var widthPercent = zone.width_percent / 100;
-            style.maxWidth = ((1 / (widthPercent / maxWidth)) * 100) + '%';
+            var possiblemaxWidth = ((1 / (widthPercent / maxWidth)) * 100);
+            style.maxWidth = (possiblemaxWidth < 100) ? possiblemaxWidth + '%' : '100%';
             if (item.widthPercent) {
                 style.width = style.maxWidth;
             }
             // Finally, if the item is using automatic sizing and contains an image, we
             // always prefer the natural width of the image (subject to the max-width):
-            if (item.imgNaturalWidth && !item.widthPercent) {
+            if (item.imgNaturalWidth && !item.widthPercent && !item.noPadding) {
                 style.width = (item.imgNaturalWidth + 22) + "px"; // 22px is for 10px padding + 1px border each side
                 // ^ Hack to detect image width at runtime and make webkit consistent with Firefox
+            }
+            if (item.noPadding) {
+                style.width = item.imgNaturalWidth + "px";
+                style.padding = '0';
             }
         } else {
             $.extend(style, bankItemWidthStyles(item, ctx));
@@ -1911,6 +1916,7 @@ function DragAndDropBlock(runtime, element, configuration) {
                 is_placed: Boolean(item_user_state),
                 widthPercent: item.widthPercent, // widthPercent may be undefined (auto width)
                 imgNaturalWidth: item.imgNaturalWidth,
+                noPadding: item.noPadding,
             };
             if (item_user_state) {
                 itemProperties.zone = item_user_state.zone;

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -348,7 +348,7 @@ function DragAndDropTemplates(configuration) {
             var attemptsUsedTemplate = gettext("You have used {used} of {total} attempts.");
             var attemptsUsedText = attemptsUsedTemplate.
                 replace("{used}", ctx.attempts).replace("{total}", ctx.max_attempts);
-            attemptsUsedInfo = h("span.attempts-used", {id: attemptsUsedId}, attemptsUsedText);
+            attemptsUsedInfo = h("div.submission-feedback", {id: attemptsUsedId}, attemptsUsedText);
         }
 
         var submitSpinner = null;
@@ -360,14 +360,16 @@ function DragAndDropTemplates(configuration) {
         }
 
         return (
-            h("div.action-toolbar-item.submit-answer", {}, [
+            h("div.submit-attempt-container", {}, [
                 h(
-                    "button.btn-brand.submit-answer-button",
+                    "button.btn-brand.submit",
                     submitButtonProperties,
                     [
-                        submitSpinner,
-                        ' ',  // whitespace between spinner icon and text
-                        gettext("Submit")
+                        h("span.submit-label", [
+                            submitSpinner,
+                            ' ',  // whitespace between spinner icon and text
+                            gettext("Submit")
+                        ])
                     ]
                 ),
                 attemptsUsedInfo
@@ -378,12 +380,12 @@ function DragAndDropTemplates(configuration) {
     var sidebarButtonTemplate = function(buttonClass, iconClass, buttonText, options) {
         options = options || {};
         if (options.spinner) {
-            iconClass = 'fa-spin.fa-spinner';
+            iconClass = 'fa-spin fa-spinner';
         }
         return (
-            h('span.sidebar-button-wrapper', {}, [
+            h('span.problem-action-button-wrapper', {}, [
                 h(
-                    'button.unbutton.btn-default.btn-small',
+                    'button.problem-action-btn.btn-default.btn-small',
                     {
                         className: buttonClass,
                         disabled: options.disabled || options.spinner || false
@@ -405,7 +407,7 @@ function DragAndDropTemplates(configuration) {
                 spinner: ctx.show_answer_spinner
             };
             showAnswerButton = sidebarButtonTemplate(
-                "show-answer-button",
+                "show",
                 "fa-info-circle",
                 gettext('Show Answer'),
                 options
@@ -416,7 +418,7 @@ function DragAndDropTemplates(configuration) {
             go_to_beginning_button_class += ' sr';
         }
         return(
-            h("div.action-toolbar-item.sidebar-buttons", {}, [
+            h("div.problem-action-buttons-wrapper", {attributes: {'role': 'group', 'aria-label': gettext('Actions')}}, [
                 sidebarButtonTemplate(
                     go_to_beginning_button_class,
                     "fa-arrow-up",
@@ -424,7 +426,7 @@ function DragAndDropTemplates(configuration) {
                     {disabled: ctx.disable_go_to_beginning_button}
                 ),
                 sidebarButtonTemplate(
-                    "reset-button",
+                    "reset",
                     "fa-refresh",
                     gettext('Reset'),
                     {disabled: ctx.disable_reset_button}
@@ -607,7 +609,7 @@ function DragAndDropTemplates(configuration) {
         var problemTitle = null;
         if (ctx.show_title) {
             var problem_title_id = configuration.url_name + '-problem-title';
-            problemTitle = h('h3.problem-title', {
+            problemTitle = h('h3.hd.hd-3.problem-header', {
                 id: problem_title_id,
                 innerHTML: gettext(ctx.title_html),
                 attributes: {'aria-describedby': problemProgress.properties.id}
@@ -684,32 +686,32 @@ function DragAndDropTemplates(configuration) {
                 h('div.problem', [
                     problemHeader,
                     h('p', {innerHTML: ctx.problem_html}),
-                ]),
-                h('div.drag-container', {style: drag_container_style}, [
-                    h('div.item-bank', item_bank_properties, bank_children),
-                    h('div.target', {attributes: {'role': 'group', 'arial-label': gettext('Drop Targets')}}, [
-                        itemFeedbackPopupTemplate(ctx),
-                        h('div.target-img-wrapper', [
-                            h('img.target-img', {
-                                src: ctx.target_img_src,
-                                alt: ctx.target_img_description,
-                                style: target_img_style
-                            }),
-                            renderCollection(zoneTemplate, ctx.zones, ctx)
+                    h('div.drag-container', {style: drag_container_style}, [
+                        h('div.item-bank', item_bank_properties, bank_children),
+                        h('div.target', {attributes: {'role': 'group', 'arial-label': gettext('Drop Targets')}}, [
+                            itemFeedbackPopupTemplate(ctx),
+                            h('div.target-img-wrapper', [
+                                h('img.target-img', {
+                                    src: ctx.target_img_src,
+                                    alt: ctx.target_img_description,
+                                    style: target_img_style
+                                }),
+                                renderCollection(zoneTemplate, ctx.zones, ctx)
+                            ]),
                         ]),
+                        h('div.dragged-items', renderCollection(itemTemplate, items_dragged, ctx)),
                     ]),
-                    h('div.dragged-items', renderCollection(itemTemplate, items_dragged, ctx)),
+                    h('div.action', [
+                        (ctx.show_submit_answer ? submitAnswerTemplate(ctx) : null),
+                        sidebarTemplate(ctx)
+                    ]),
+                    keyboardHelpPopupTemplate(ctx),
+                    feedbackTemplate(ctx),
+                    h('div.sr.reader-feedback-area', {
+                        attributes: {'aria-live': 'polite', 'aria-atomic': true},
+                        innerHTML: ctx.screen_reader_messages
+                    }),
                 ]),
-                h("div.actions-toolbar", {attributes: {'role': 'group', 'aria-label': gettext('Actions')}}, [
-                    (ctx.show_submit_answer ? submitAnswerTemplate(ctx) : null),
-                    sidebarTemplate(ctx),
-                ]),
-                keyboardHelpPopupTemplate(ctx),
-                feedbackTemplate(ctx),
-                h('div.sr.reader-feedback-area', {
-                    attributes: {'aria-live': 'polite', 'aria-atomic': true},
-                    innerHTML: ctx.screen_reader_messages
-                }),
             ])
         );
     };
@@ -800,17 +802,17 @@ function DragAndDropBlock(runtime, element, configuration) {
             $element.on('keydown', '.item-feedback-popup .close-feedback-popup-button', closePopupKeydownHandler);
             $element.on('keyup', '.item-feedback-popup .close-feedback-popup-button', preventFauxPopupCloseButtonClick);
 
-            $element.on('click', '.submit-answer-button', doAttempt);
+            $element.on('click', '.xblock--drag-and-drop .submit-attempt-container .submit', doAttempt);
             $element.on('click', '.keyboard-help-button', showKeyboardHelp);
             $element.on('keydown', '.keyboard-help-button', function(evt) {
                 runOnKey(evt, RET, showKeyboardHelp);
             });
-            $element.on('click', '.reset-button', resetProblem);
-            $element.on('keydown', '.reset-button', function(evt) {
+            $element.on('click', '.xblock--drag-and-drop .problem-action-button-wrapper .reset', resetProblem);
+            $element.on('keydown', '.xblock--drag-and-drop .problem-action-button-wrapper .reset', function(evt) {
                 runOnKey(evt, RET, resetProblem);
             });
-            $element.on('click', '.show-answer-button', showAnswer);
-            $element.on('keydown', '.show-answer-button', function(evt) {
+            $element.on('click', '.xblock--drag-and-drop .problem-action-button-wrapper .show', showAnswer);
+            $element.on('keydown', '.xblock--drag-and-drop .problem-action-button-wrapper .show', function(evt) {
                 runOnKey(evt, RET, showAnswer);
             });
 

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -620,6 +620,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                                     // block, but preserve the data in case we need it again:
                                     ctx.pixelHeight = itemData.size.height.substr(0, itemData.size.height.length - 2); // Remove 'px'
                                 }
+                                ctx.noPadding = (ctx.noPadding) ? 'checked' : '';
                             }
                             ctx.checkboxes = _fn.build.form.createCheckboxes(ctx.zones);
 
@@ -668,7 +669,8 @@ function DragAndDropEditBlock(runtime, element, params) {
                                 name = $el.find('.item-text').val(),
                                 imageURL = $el.find('.item-image-url').val(),
                                 imageDescription = $el.find('.item-image-description').val(),
-                                selectedZones = $el.find('.zone-checkbox:checked');
+                                selectedZones = $el.find('.zone-checkbox:checked'),
+                                noPadding = $el.find('.img-checkbox').is(':checked');
 
                             if (name.length > 0 || imageURL.length > 0) {
                                 var data = {
@@ -683,6 +685,7 @@ function DragAndDropEditBlock(runtime, element, params) {
                                     },
                                     imageURL: imageURL,
                                     imageDescription: imageDescription,
+                                    noPadding: (imageURL ? noPadding : false),
                                 };
                                 // Optional preferred width as a percentage of the bg image's width:
                                 var widthPercent = $el.find('.item-width').val();

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -205,6 +205,10 @@ function DragAndDropEditBlock(runtime, element, params) {
                             $('.display-borders-form input', element).prop('checked', true);
                         }
 
+                        if (_fn.data.displayBordersDragging) {
+                            $('.display-borders-dragging-form input', element).prop('checked', true);
+                        }
+
                         $fbkTab.addClass('hidden');
                         $zoneTab.removeClass('hidden');
                         self.scrollToTop();
@@ -288,6 +292,9 @@ function DragAndDropEditBlock(runtime, element, params) {
                         })
                         .on('click', '.display-borders-form input', function(e) {
                             _fn.data.displayBorders = $('.display-borders-form input', element).is(':checked');
+                        })
+                        .on('click', '.display-borders-dragging-form input', function(e) {
+                            _fn.data.displayBordersDragging = $('.display-borders-dragging-form input', element).is(':checked');
                         });
 
                     $itemTab

--- a/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
+++ b/drag_and_drop_v2/templates/html/drag_and_drop_edit.html
@@ -190,6 +190,12 @@
                         <span>{% trans "Display zone borders on the image" %}</span>
                     </label>
                 </form>
+                <form class="display-borders-dragging-form">
+                    <label class="checkbox-label">
+                        <input name="display-borders-dragging" class="display-borders-dragging" type="checkbox" />
+                        <span>{% trans "Display zone borders when dragging an item" %}</span>
+                    </label>
+                </form>
             </div>
             <div class="tab-content">
                 <h4>{% trans "Zone definitions" %}</h4>

--- a/drag_and_drop_v2/templates/html/js_templates.html
+++ b/drag_and_drop_v2/templates/html/js_templates.html
@@ -141,6 +141,14 @@
             </label>
         </div>
         <div class="row">
+            <label class="checkbox-label">
+                <input type="checkbox"
+                       class="img-checkbox"
+                       {{ noPadding }} />
+                    {{i18n "Remove padding when dropped on a zone (applies only to images)."}}
+            </label>
+        </div>
+        <div class="row">
             <label class="h4">
                 <span>{{i18n "Success feedback"}}</span>
                 <textarea class="success-feedback">{{i18n feedback.correct}}</textarea>

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.3.7',
+    version='2.3.8',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[

--- a/tests/integration/test_base.py
+++ b/tests/integration/test_base.py
@@ -138,16 +138,16 @@ class BaseIntegrationTest(SeleniumBaseTest):
         return self._page.find_element_by_css_selector('.go-to-beginning-button')
 
     def _get_reset_button(self):
-        return self._page.find_element_by_css_selector('.reset-button')
+        return self._page.find_element_by_css_selector('.problem-action-button-wrapper .reset')
 
     def _get_show_answer_button(self):
-        return self._page.find_element_by_css_selector('.show-answer-button')
+        return self._page.find_element_by_css_selector('.problem-action-button-wrapper .show')
 
     def _get_submit_button(self):
-        return self._page.find_element_by_css_selector('.submit-answer-button')
+        return self._page.find_element_by_css_selector('.submit-attempt-container .submit')
 
     def _get_attempts_info(self):
-        return self._page.find_element_by_css_selector('.attempts-used')
+        return self._page.find_element_by_css_selector('.submission-feedback')
 
     def _get_feedback(self):
         return self._page.find_element_by_css_selector(".feedback-content")

--- a/tests/integration/test_sizing.py
+++ b/tests/integration/test_sizing.py
@@ -104,7 +104,7 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
         # A 400x300 image with automatic sizing should be constrained to the maximum width
         Expectation(item_id=5, zone_id=ZONE_50, width_percent=AUTO_MAX_WIDTH_DESKTOP),
         # A 200x200 image with automatic sizing
-        Expectation(item_id=6, zone_id=ZONE_50, width_percent=[25, 30.2]),
+        Expectation(item_id=6, zone_id=ZONE_50, width_percent=[24, 30.2]),
         # A 400x300 image with a specified width of 50%
         Expectation(item_id=7, zone_id=ZONE_50, fixed_width_percent=50),
         # A 200x200 image with a specified width of 50%
@@ -247,7 +247,6 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
 
     def _check_sizes(self, block_index, expectations, expected_img_width=None, is_desktop=True):
         """ Test the actual dimensions that each draggable has, in the bank and when placed """
-        # Check assumptions - the container wrapping this XBlock should be 770px wide
         self._switch_to_block(block_index)
         target_img = self._page.find_element_by_css_selector('.target-img')
         target_img_width = target_img.size["width"]
@@ -257,8 +256,8 @@ class SizingTests(InteractionTestBase, BaseIntegrationTest):
         page_width = self._page.size["width"]  # self._page is the .xblock--drag-and-drop div
 
         if is_desktop:
-            # If using a desktop-sized window, we can know the exact dimensions of various containers:
-            self.assertEqual(page_width, 770)  # div has max-width: 770px
+            window_width = self.browser.get_window_size()["width"]
+            self.assertLessEqual(window_width, 1024)
         else:
             window_width = self.browser.get_window_size()["width"]
             self.assertLessEqual(window_width, 400)

--- a/tests/integration/test_title_and_question.py
+++ b/tests/integration/test_title_and_question.py
@@ -55,8 +55,8 @@ class TestDragAndDropTitleAndProblem(BaseIntegrationTest):
 
         page = self.go_to_page(const_page_name)
         if show_title:
-            problem_header = page.find_element_by_css_selector('h3.problem-title')
+            problem_header = page.find_element_by_css_selector('h3.hd.hd-3.problem-header')
             self.assertEqual(self.get_element_html(problem_header), display_name)
         else:
             with self.assertRaises(NoSuchElementException):
-                page.find_element_by_css_selector('h3.problem-title')
+                page.find_element_by_css_selector('h3.hd.hd-3.problem-header')

--- a/tests/unit/data/assessment/config_out.json
+++ b/tests/unit/data/assessment/config_out.json
@@ -16,6 +16,7 @@
     "item_background_color": null,
     "item_text_color": null,
     "display_zone_borders": false,
+    "display_zone_borders_dragging": false,
     "display_zone_labels": false,
     "url_name": "test",
     "max_items_per_zone": null,

--- a/tests/unit/data/html/config_out.json
+++ b/tests/unit/data/html/config_out.json
@@ -16,6 +16,7 @@
     "item_background_color": "white",
     "item_text_color": "#000080",
     "display_zone_borders": false,
+    "display_zone_borders_dragging": false,
     "display_zone_labels": false,
     "url_name": "unique_name",
     "max_items_per_zone": null,

--- a/tests/unit/data/old/config_out.json
+++ b/tests/unit/data/old/config_out.json
@@ -16,6 +16,7 @@
     "item_background_color": null,
     "item_text_color": null,
     "display_zone_borders": false,
+    "display_zone_borders_dragging": false,
     "display_zone_labels": false,
     "url_name": "",
     "max_items_per_zone": null,

--- a/tests/unit/data/plain/config_out.json
+++ b/tests/unit/data/plain/config_out.json
@@ -16,6 +16,7 @@
     "item_background_color": null,
     "item_text_color": null,
     "display_zone_borders": false,
+    "display_zone_borders_dragging": false,
     "display_zone_labels": false,
     "url_name": "test",
     "max_items_per_zone": 4,

--- a/tests/unit/test_basics.py
+++ b/tests/unit/test_basics.py
@@ -88,6 +88,7 @@ class BasicTests(TestCaseMixin, unittest.TestCase):
             "graded": False,
             "weighted_max_score": 1,
             "display_zone_borders": False,
+            "display_zone_borders_dragging": False,
             "display_zone_labels": False,
             "title": "Drag and Drop",
             "show_title": True,


### PR DESCRIPTION
## Description
These changes include:
- Remove max-width
- Fix title css classes
- Hides text from draggable until gets processed after drop
- Change containers and css classes to use those from openedx 
- Feature: add option to show zone border when dragging an item 
![borders-dragging](https://user-images.githubusercontent.com/363698/155030731-8afa88d4-78ea-4e62-bfcb-034e2ab1a488.gif)

- Feature: add item option to remove padding from images dropped on a zone
![no-padding](https://user-images.githubusercontent.com/363698/155030802-f829f0cd-6769-4210-a9d3-900f493a87c9.gif)

- Improve feedback styles, now only icons shows color related with feedback and text color remains the same also each feedback line doesn't show borders.
![Captura de Pantalla 2022-03-31 a la(s) 8 45 50 p  m](https://user-images.githubusercontent.com/363698/161179635-7db5a381-b38d-4ba3-933e-762d75408ff1.png)

## Testing instructions
To test the way it hides text until drops gets processed:
1. With the standard demo of drag and drop v2, grab the text item that belongs to top
2. Drop it into the top zone and see how the text gets replaced by the spinner icon but doesn't change item size, once it's processed the text should appear back

These instructions are for testing the new added features.
Remove padding:
1. Add an image to the assets, let's say for this example an image of 60x60px
3. Add a drag and drop v2 xblock 
4. Edit configuration, add a zone of 60x60px or the image size
5. Add the image as a new item and check "Remove padding when dropped on a zone (applies only to images)"
6. Finally, drag that image into that zone, and you should see how that fit well without any padding 

Add border to drag zone:
1. Edit configuration, move onto zones configuration and check "Display zone borders when dragging an item"
2. Drag some element into the zones, and you will see a border added to each zone when dragging over them. Note that when ""Display zone borders on the image" and "Display zone borders when dragging an item" the first takes precedence and will only display the regular borders on the zone.

Supporting information
None

Deadline
None