### PR TITLE
test: verify CI on the `master` branch

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@ Drag and Drop XBlock changelog
 ==============================
 
 Unreleased
----------------------------
+----------
 * Replaced `Travis` with `GitHub CI`.
 
 Version 2.3.7 (2022-02-20)


### PR DESCRIPTION
The CI is failing in #280 and #282. This wasn't the case until we've rebased them to include the Travis -> Github Actions change. This is a temporary PR to verify what is causing these failures.