### PR TITLE
[BB-6300] fix: inconsistency in grabbed draggable item width

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,10 @@
 Drag and Drop XBlock changelog
 ==============================
 
-Unreleased
-----------
+Version 2.3.9 (2022-06-15)
+---------------------------
 
+* Fix draggable item width inconsistency while dragging.
 * Do not move correctly placed items when showing the answer.
 * Distribute items with multiple correct zones among these zones when showing the answer.
 

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -83,9 +83,6 @@ function DragAndDropTemplates(configuration) {
         if (item.widthPercent) {
             className += " specified-width";  // The author has specified a width for this item.
         }
-        if (item.grabbed_with) {
-            className += " grabbed-with-" + item.grabbed_with;
-        }
         var attributes = {
             'role': 'button',
             'draggable': !item.drag_disabled,
@@ -130,6 +127,14 @@ function DragAndDropTemplates(configuration) {
                 style.padding = '0';
             }
         } else {
+            $.extend(style, bankItemWidthStyles(item, ctx));
+        }
+        if (item.grabbed_with) {
+            className += " grabbed-with-" + item.grabbed_with;
+            // Clear width and maxWidth styles and use the bankItemWidthStyles
+            // This prevents inconsistency in width for grabbed items
+            delete style.width
+            delete style.maxWidth
             $.extend(style, bankItemWidthStyles(item, ctx));
         }
         // Define children

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.3.8',
+    version='2.3.9',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
## Description

This PR fixes inconsistencies in the width of draggable items when grabbed from a drop zone.

The width/maxWidth of a draggable item is calculated in percentage according to the width of the drop zone.

When an item is grabbed from a drop zone, the item is moved to the draggable area div, whose width is larger than the drop zone, and so calculated width percentage of the item would now be in relation to the entire draggable area.

This let to inconsistencies, if different drop zone were of different widths and/or the width of the last drop zone is smaller than the actual width of the draggable item.

**Before:**
![Before](https://user-images.githubusercontent.com/36229857/172584959-f8166cd3-02a5-416f-bca3-2c1798d739fc.gif)

**After:**
![After](https://user-images.githubusercontent.com/36229857/172584984-af8f2189-383f-4650-9224-590b4bb939d2.gif)


## Supporting information

OpenCraft internal ticket [BB-6300](https://tasks.opencraft.com/browse/BB-6300)

## Testing instructions

1. Checkout this branch in `<devstack_parent>/src` directory in your local setup
2. Login to Studio shell, switch to `edxapp` virtual env
3. Go to `/edx/src/xblock-drag-and-drop-v2` and run `pip install -e .`
4. Go to Studio UI and create a new unit
5. Select `Problem` > `Advanced` > `Drag and Drop`, to create a v2 drag and drop xblock
6. Click `Edit` and change mode to `Assessment`
7. Click `Continue` twice
8. Scroll down to first item definition, click on `Show advanced settings` and set preferred width to `50%`
9. Click `Save`
10. Grab the item for which the width was just set. Visually note the width of the item
11.  Drop it to the top zone
12. Grab the item again from the top zone, the item width should equal to the width when first grabbed.
13. Drop the item to the bottom zone
14. Grab the item again from the bottom zone, the item width should be equal to width when first grabbed.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.