### PR TITLE
feat: use platform translations as a fallback when XBlock translations are missing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 Drag and Drop XBlock changelog
 ==============================
 
+Version 2.3.11 (2022-07-22)
+---------------------------
+
+* Use global (platform-wide) translations as a fallback when XBlock translations are missing. \
+  This change also has an intended side effect - it allows overriding English text with comprehensive themes (by patching the default translation catalog).
+
 Version 2.3.10 (2022-07-22)
 ---------------------------
 

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -6,22 +6,22 @@ function DragAndDropTemplates(configuration) {
     if ('DragAndDropI18N' in window) {
         // Use DnDv2's local translations
         gettext = function(string) {
-            let translated = window.DragAndDropI18N.gettext(string);
+            var translated = window.DragAndDropI18N.gettext(string);
             // if DnDv2's translation is the same as the input, check if global has a different value
             // This is useful for overriding the XBlock's string by themes (only for English)
             if (string === translated && 'gettext' in window) {
                 translated = window.gettext(string);
             }
             return translated;
-        }
+        };
         ngettext = function(strA, strB, n) {
-            let translated = window.DragAndDropI18N.ngettext(strA, strB, n);
-            let string = n == 1 ? strA : strB;
+            var translated = window.DragAndDropI18N.ngettext(strA, strB, n);
+            var string = n == 1 ? strA : strB;
             if (string === translated && 'gettext' in window) {
                 translated = window.gettext(strA, strB, n);
             }
             return translated;
-        }
+        };
     } else if ('gettext' in window) {
         // Use edxapp's global translations
         gettext = window.gettext;

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -5,8 +5,23 @@ function DragAndDropTemplates(configuration) {
     var ngettext;
     if ('DragAndDropI18N' in window) {
         // Use DnDv2's local translations
-        gettext = window.DragAndDropI18N.gettext;
-        ngettext = window.DragAndDropI18N.ngettext;
+        gettext = function(string) {
+            let translated = window.DragAndDropI18N.gettext(string);
+            // if DnDv2's translation is the same as the input, check if global has a different value
+            // This is useful for overriding the XBlock's string by themes (only for English)
+            if (string === translated && 'gettext' in window) {
+                translated = window.gettext(string);
+            }
+            return translated;
+        }
+        ngettext = function(strA, strB, n) {
+            let translated = window.DragAndDropI18N.ngettext(strA, strB, n);
+            let string = n == 1 ? strA : strB;
+            if (string === translated && 'gettext' in window) {
+                translated = window.gettext(strA, strB, n);
+            }
+            return translated;
+        }
     } else if ('gettext' in window) {
         // Use edxapp's global translations
         gettext = window.gettext;

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1,27 +1,22 @@
 function DragAndDropTemplates(configuration) {
     "use strict";
 
-    // Fetch the platform translations if available, or fallback to the
-    // local translations. This allows overriding of translations in themes
-    // by patching the global translations.
-    var gettext = function(string) {
-        return 'gettext' in window ?
-            window.gettext(string) :
-            (
-                'DragAndDropI18N' in window ?
-                window.DragAndDropI18N.gettext(string) :
-                string
-            );
+    var gettext;
+    var ngettext;
+    if ('DragAndDropI18N' in window) {
+        // Use DnDv2's local translations
+        gettext = window.DragAndDropI18N.gettext;
+        ngettext = window.DragAndDropI18N.ngettext;
+    } else if ('gettext' in window) {
+        // Use edxapp's global translations
+        gettext = window.gettext;
+        ngettext = window.ngettext;
     }
-    var ngettext = function(strA, strB, n) {
-        return 'gettext' in window ?
-            window.ngettext(strA, strB, n) :
-            (
-                'DragAndDropI18N' in window ?
-                window.DragAndDropI18N.ngettext(strA, strB, n) :
-                (n == 1 ? strA : strB)
-            );
-    };
+    if (typeof gettext == "undefined") {
+        // No translations -- used by test environment
+        gettext = function(string) { return string; };
+        ngettext = function(strA, strB, n) { return n == 1 ? strA : strB; };
+    }
     var h = virtualDom.h;
 
     var isMobileScreen = function() {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1,22 +1,27 @@
 function DragAndDropTemplates(configuration) {
     "use strict";
 
-    var gettext;
-    var ngettext;
-    if ('DragAndDropI18N' in window) {
-        // Use DnDv2's local translations
-        gettext = window.DragAndDropI18N.gettext;
-        ngettext = window.DragAndDropI18N.ngettext;
-    } else if ('gettext' in window) {
-        // Use edxapp's global translations
-        gettext = window.gettext;
-        ngettext = window.ngettext;
+    // Fetch the platform translations if available, or fallback to the
+    // local translations. This allows overriding of translations in themes
+    // by patching the global translations.
+    var gettext = function(string) {
+        return 'gettext' in window ?
+            window.gettext(string) :
+            (
+                'DragAndDropI18N' in window ?
+                window.DragAndDropI18N.gettext(string) :
+                string
+            );
     }
-    if (typeof gettext == "undefined") {
-        // No translations -- used by test environment
-        gettext = function(string) { return string; };
-        ngettext = function(strA, strB, n) { return n == 1 ? strA : strB; };
-    }
+    var ngettext = function(strA, strB, n) {
+        return 'gettext' in window ?
+            window.ngettext(strA, strB, n) :
+            (
+                'DragAndDropI18N' in window ?
+                window.DragAndDropI18N.ngettext(strA, strB, n) :
+                (n == 1 ? strA : strB)
+            );
+    };
     var h = virtualDom.h;
 
     var isMobileScreen = function() {

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -5,22 +5,22 @@ function DragAndDropEditBlock(runtime, element, params) {
     if ('DragAndDropI18N' in window) {
         // Use DnDv2's local translations
         gettext = function(string) {
-            let translated = window.DragAndDropI18N.gettext(string);
+            var translated = window.DragAndDropI18N.gettext(string);
             // if DnDv2's translation is the same as the input, check if global has a different value
             // This is useful for overriding the XBlock's string by themes (only for English)
             if (string === translated && 'gettext' in window) {
                 translated = window.gettext(string);
             }
             return translated;
-        }
+        };
         ngettext = function(strA, strB, n) {
-            let translated = window.DragAndDropI18N.ngettext(strA, strB, n);
-            let string = n == 1 ? strA : strB;
+            var translated = window.DragAndDropI18N.ngettext(strA, strB, n);
+            var string = n == 1 ? strA : strB;
             if (string === translated && 'gettext' in window) {
                 translated = window.gettext(strA, strB, n);
             }
             return translated;
-        }
+        };
     } else if ('gettext' in window) {
         // Use edxapp's global translations
         gettext = window.gettext;

--- a/drag_and_drop_v2/public/js/drag_and_drop_edit.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop_edit.js
@@ -4,8 +4,23 @@ function DragAndDropEditBlock(runtime, element, params) {
     var ngettext;
     if ('DragAndDropI18N' in window) {
         // Use DnDv2's local translations
-        gettext = window.DragAndDropI18N.gettext;
-        ngettext = window.DragAndDropI18N.ngettext;
+        gettext = function(string) {
+            let translated = window.DragAndDropI18N.gettext(string);
+            // if DnDv2's translation is the same as the input, check if global has a different value
+            // This is useful for overriding the XBlock's string by themes (only for English)
+            if (string === translated && 'gettext' in window) {
+                translated = window.gettext(string);
+            }
+            return translated;
+        }
+        ngettext = function(strA, strB, n) {
+            let translated = window.DragAndDropI18N.ngettext(strA, strB, n);
+            let string = n == 1 ? strA : strB;
+            if (string === translated && 'gettext' in window) {
+                translated = window.gettext(strA, strB, n);
+            }
+            return translated;
+        }
     } else if ('gettext' in window) {
         // Use edxapp's global translations
         gettext = window.gettext;

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.3.10',
+    version='2.3.11',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[


### PR DESCRIPTION
This adds a wrapper for `gettext` and `ngettext`, which uses global (platform-wide) translations when a translation is missing in the XBlock.

As a side effect, this allows overriding English text with comprehensive themes (by patching the default translation catalog).

Internal ticket: BB-6465