### PR TITLE
Build: add test path as an optional parameter to test.unit command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,6 @@ test.quality: ## run quality checkers on the codebase
 	pylint tests --rcfile=tests/pylintrc
 
 test.unit: ## run python unit and integration tests
-	PATH=test_helpers/firefox:$$PATH xvfb-run python run_tests.py
+	PATH=test_helpers/firefox:$$PATH xvfb-run python run_tests.py $(filter-out $@,$(MAKECMDGOALS))
 
 test: test.quality test.unit ## Run all tests

--- a/README.md
+++ b/README.md
@@ -471,6 +471,12 @@ Similarly, you can run unit and integration test suite via
 $ make test.unit
 ```
 
+You can run specific tests via
+
+```bash
+$ make test.unit tests.unit.test_basics.BasicTests.test_student_view_data
+```
+
 
 i18n compatibility
 ==================


### PR DESCRIPTION
This:

- add an optional test path like ```tests.integration.test_interaction_assessment``` to  Makefile command ```test.unit```