### PR TITLE
[BB-6875] Add option to drop decoy item from scores

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 Drag and Drop XBlock changelog
 ==============================
 
+Version 2.6.0 (2022-10-24)
+---------------------------
+
+* Add package publishing workflow.
+
 Version 2.5.0 (2022-10-13)
 ---------------------------
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 Drag and Drop XBlock changelog
 ==============================
 
+Version 2.7.0 (2022-11-15)
+---------------------------
+
+* Add option to drop decoy items from scores
+
 Version 2.6.0 (2022-10-24)
 ---------------------------
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ score would be `100%`:
 
     score = (3 + 1) / 4
 
+Optionally, there is an alternative grading that can be enabled, by setting the
+waffle flag `drag_and_drop_v2.enable_alternative_grading`, which will drop
+the decoy items entirely from the score calculation. The formula will change to:
+
+    score = C / R
+
+Where *C* is the number of correctly placed regular items, *R* is the number of
+required regular items.
+
 Demo Course
 -----------
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ score would be `100%`:
     score = (3 + 1) / 4
 
 Optionally, there is an alternative grading that can be enabled, by setting the
-waffle flag `drag_and_drop_v2.enable_alternative_grading`, which will drop
+waffle flag `drag_and_drop_v2.grading_ignore_decoys`, which will drop
 the decoy items entirely from the score calculation. The formula will change to:
 
     score = C / R

--- a/drag_and_drop_v2/compat.py
+++ b/drag_and_drop_v2/compat.py
@@ -24,4 +24,9 @@ def get_grading_ignore_decoys_waffle_flag():
     """
     # pylint: disable=import-error,import-outside-toplevel
     from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
-    return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{GRADING_IGNORE_DECOYS}', __name__)
+    try:
+        # HACK: The base class of the `CourseWaffleFlag` was changed in Olive.
+        #  Ref: https://github.com/openedx/public-engineering/issues/28
+        return CourseWaffleFlag(WAFFLE_NAMESPACE, GRADING_IGNORE_DECOYS, __name__)
+    except ValueError:
+        return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{GRADING_IGNORE_DECOYS}', __name__)

--- a/drag_and_drop_v2/compat.py
+++ b/drag_and_drop_v2/compat.py
@@ -8,22 +8,20 @@ Compatibility layer to isolate core-platform waffle flags from implementation.
 WAFFLE_NAMESPACE = "drag_and_drop_v2"
 
 # Course Waffle Flags
-# .. toggle_name: drag_and_drop_v2.enable_alternative_grading
+# .. toggle_name: drag_and_drop_v2.grading_ignore_decoys
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Enables alternative grading for the xblock
 #    that does not include decoy items in the score.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2022-11-10
-# .. toggle_tickets: <>
-# .. toggle_warning: None.
-ENABLE_ALTERNATIVE_GRADING = 'enable_alternative_grading'
+GRADING_IGNORE_DECOYS = 'grading_ignore_decoys'
 
 
-def get_config_waffle_flag():
+def get_grading_ignore_decoys_waffle_flag():
     """
     Import and return Waffle flag for enabling alternative grading for drag_and_drop_v2 Xblock.
     """
     # pylint: disable=import-error,import-outside-toplevel
     from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
-    return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_ALTERNATIVE_GRADING}', __name__)
+    return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{GRADING_IGNORE_DECOYS}', __name__)

--- a/drag_and_drop_v2/compat.py
+++ b/drag_and_drop_v2/compat.py
@@ -1,0 +1,29 @@
+"""
+Compatibility layer to isolate core-platform waffle flags from implementation.
+"""
+
+# Waffle flags configuration
+
+# Namespace
+WAFFLE_NAMESPACE = "drag_and_drop_v2"
+
+# Course Waffle Flags
+# .. toggle_name: drag_and_drop_v2.enable_alternative_grading
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables alternative grading for the xblock
+#    that does not include decoy items in the score.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2022-11-10
+# .. toggle_tickets: <>
+# .. toggle_warning: None.
+ENABLE_ALTERNATIVE_GRADING = 'enable_alternative_grading'
+
+
+def get_config_waffle_flag():
+    """
+    Import and return Waffle flag for enabling alternative grading for drag_and_drop_v2 Xblock.
+    """
+    # pylint: disable=import-error,import-outside-toplevel
+    from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+    return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{ENABLE_ALTERNATIVE_GRADING}', __name__)

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -27,6 +27,7 @@ from web_fragments.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 from xblockutils.settings import ThemableXBlockMixin, XBlockWithSettingsMixin
 
+from .compat import get_config_waffle_flag
 from .default_data import DEFAULT_DATA
 from .utils import (
     Constants, SHOWANSWER, DummyTranslationService, FeedbackMessage,
@@ -1212,8 +1213,14 @@ class DragAndDropBlock(
         """
         items = self._get_item_raw_stats()
 
-        correct_count = len(items.correctly_placed) + len(items.decoy_in_bank)
-        total_count = len(items.required) + len(items.decoy)
+        correct_count = len(items.correctly_placed)
+        total_count = len(items.required)
+
+        if hasattr(self.runtime, 'course_id') and get_config_waffle_flag().is_enabled(self.runtime.course_id):
+            return correct_count, total_count
+
+        correct_count += len(items.decoy_in_bank)
+        total_count += len(items.decoy)
 
         return correct_count, total_count
 

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -27,7 +27,7 @@ from web_fragments.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 from xblockutils.settings import ThemableXBlockMixin, XBlockWithSettingsMixin
 
-from .compat import get_config_waffle_flag
+from .compat import get_grading_ignore_decoys_waffle_flag
 from .default_data import DEFAULT_DATA
 from .utils import (
     Constants, SHOWANSWER, DummyTranslationService, FeedbackMessage,
@@ -1216,7 +1216,8 @@ class DragAndDropBlock(
         correct_count = len(items.correctly_placed)
         total_count = len(items.required)
 
-        if hasattr(self.runtime, 'course_id') and get_config_waffle_flag().is_enabled(self.runtime.course_id):
+        if hasattr(self.scope_ids.usage_id, 'context_key') and \
+                get_grading_ignore_decoys_waffle_flag().is_enabled(self.scope_ids.usage_id.context_key):
             return correct_count, total_count
 
         correct_count += len(items.decoy_in_bank)

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -1216,8 +1216,8 @@ class DragAndDropBlock(
         correct_count = len(items.correctly_placed)
         total_count = len(items.required)
 
-        if hasattr(self.scope_ids.usage_id, 'context_key') and \
-                get_grading_ignore_decoys_waffle_flag().is_enabled(self.scope_ids.usage_id.context_key):
+        if hasattr(self.runtime, 'course_id') and \
+                get_grading_ignore_decoys_waffle_flag().is_enabled(self.runtime.course_id):
             return correct_count, total_count
 
         correct_count += len(items.decoy_in_bank)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.5.1',
+    version='2.7.0',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-drag-and-drop-v2',
-    version='2.5.0',
+    version='2.5.1',
     description='XBlock - Drag-and-Drop v2',
     packages=['drag_and_drop_v2'],
     install_requires=[

--- a/tests/unit/test_standard_mode.py
+++ b/tests/unit/test_standard_mode.py
@@ -136,7 +136,10 @@ class StandardModeFixture(BaseDragAndDropAjaxFixture):
         self.assertEqual(1, self.block.raw_earned)
         self.assertEqual({'value': 1, 'max_value': 1, 'only_if_higher': None}, published_grades[-1])
 
-    @patch('drag_and_drop_v2.drag_and_drop_v2.get_grading_ignore_decoys_waffle_flag', lambda: Mock(is_enabled=lambda _: True))
+    @patch(
+        'drag_and_drop_v2.drag_and_drop_v2.get_grading_ignore_decoys_waffle_flag',
+        lambda: Mock(is_enabled=lambda _: True),
+    )
     @ddt.data(*[random.randint(1, 50) for _ in range(5)])  # pylint: disable=star-args
     def test_grading_ignore_decoy(self, weight):
         self.block.weight = weight

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ import json
 import random
 import re
 
-from mock import patch
+from mock import Mock, patch
 from six.moves import range
 from webob import Request
 from workbench.runtime import WorkbenchRuntime
@@ -30,6 +30,7 @@ def make_block():
     key_store = DictKeyValueStore()
     field_data = KvsFieldData(key_store)
     runtime = WorkbenchRuntime()
+    runtime.course_id = "dummy_course_id"
     def_id = runtime.id_generator.create_definition(block_type)
     usage_id = runtime.id_generator.create_usage(def_id)
     scope_ids = ScopeIds('user', block_type, def_id, usage_id)
@@ -65,7 +66,8 @@ class TestCaseMixin(object):
             create=True,
         )
         self.apply_patch(
-            'drag_and_drop_v2.drag_and_drop_v2.get_grading_ignore_decoys_waffle_flag'
+            'drag_and_drop_v2.drag_and_drop_v2.get_grading_ignore_decoys_waffle_flag',
+            lambda: Mock(is_enabled=lambda _: False),
         )
 
     def apply_patch(self, *args, **kwargs):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,6 +64,9 @@ class TestCaseMixin(object):
             lambda _, html: re.sub(r'"/static/([^"]*)"', r'"/course/test-course/assets/\1"', html),
             create=True,
         )
+        self.apply_patch(
+            'drag_and_drop_v2.drag_and_drop_v2.get_config_waffle_flag'
+        )
 
     def apply_patch(self, *args, **kwargs):
         new_patch = patch(*args, **kwargs)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,7 +65,7 @@ class TestCaseMixin(object):
             create=True,
         )
         self.apply_patch(
-            'drag_and_drop_v2.drag_and_drop_v2.get_config_waffle_flag'
+            'drag_and_drop_v2.drag_and_drop_v2.get_grading_ignore_decoys_waffle_flag'
         )
 
     def apply_patch(self, *args, **kwargs):


### PR DESCRIPTION
## Description

This PR adds an option to drop the decoy items from the scores calculation. It introduces a waffle flag called `drag_and_drop_v2.enable_alternative_grading` which will need to be enabled for using the alternative grading.

## Supporting Information

OpenCraft internal ticket: [BB-6875](https://tasks.opencraft.com/browse/BB-6875)

## Testing Instructions

1. Checkout this branch in <devstack_parent>/src directory in your local setup
2. Login to Studio shell, switch to edxapp virtual env
3. Go to /edx/src/xblock-drag-and-drop-v2 and run pip install -e
4. Go to lms admin panel and add and enable the waffle flag `drag_and_drop_v2.enable_alternative_grading`
5. In the demo course in Studio, create a new unit with a drag and drop problem
6. Switch to the unit's page in LMS and place the "I don't belong anywhere" item in any of the zones and submit.
7. Verify that the score remains 0


