### PR TITLE
build: use variables to specify individual tests to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,6 @@ test.quality: ## run quality checkers on the codebase
 	pylint tests --rcfile=tests/pylintrc
 
 test.unit: ## run python unit and integration tests
-	PATH=test_helpers/firefox:$$PATH xvfb-run python run_tests.py $(filter-out $@,$(MAKECMDGOALS))
+	PATH=test_helpers/firefox:$$PATH xvfb-run python run_tests.py $(TEST)
 
 test: test.quality test.unit ## Run all tests

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ $ make test.unit
 You can run specific tests via
 
 ```bash
-$ make test.unit tests.unit.test_basics.BasicTests.test_student_view_data
+$ make test.unit TEST=tests.unit.test_basics.BasicTests.test_student_view_data
 ```
 
 


### PR DESCRIPTION
Using `filter-out` is hacky and breaks the `make test` command on Fedora.