### PR TITLE
fix: include static files in Python package

### DIFF
--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,4 +1,4 @@
 """ Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def load_requirements(*requirements_paths):
     constraint_files = set()
 
     # groups "pkg<=x.y.z,..." into ("pkg", "<=x.y.z,...")
-    requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.]+)([<>=][^#\s]+)?")
+    requirement_line_regex = re.compile(r"([a-zA-Z0-9-_.\[\]]+)([<>=][^#\s]+)?")
 
     def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
         regex_match = requirement_line_regex.match(current_line)

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,17 @@ def get_version(*file_paths):
     raise RuntimeError('Unable to find version string.')
 
 
+def package_data(pkg, root_list):
+    """Generic function to find package_data for `pkg` under `root`."""
+    data = []
+    for root in root_list:
+        for dirname, _, files in os.walk(os.path.join(pkg, root)):
+            for fname in files:
+                data.append(os.path.relpath(os.path.join(dirname, fname), pkg))
+
+    return {pkg: data}
+
+
 VERSION = get_version('drag_and_drop_v2', '__init__.py')
 
 if sys.argv[-1] == 'tag':
@@ -108,10 +119,7 @@ setup(
     entry_points={
         'xblock.v1': 'drag-and-drop-v2 = drag_and_drop_v2:DragAndDropBlock',
     },
-    include_package_data=True,
-    packages=find_packages(
-        include=['drag_and_drop_v2', 'drag_and_drop_v2.*'],
-        exclude=["*tests"],
-    ),
+    packages=['drag_and_drop_v2'],
+    package_data=package_data("drag_and_drop_v2", ["static", "templates", "public", "translations", "locale"]),
     python_requires=">=3.8",
 )


### PR DESCRIPTION
1. The static files were not included in the previous Python packages. We could add something like this to the `MANIFEST.in` file to fix it:
    ```
    recursive-include drag_and_drop_v2/public/css *.css
    recursive-include drag_and_drop_v2/public/themes *.css
    recursive-include drag_and_drop_v2/public/img *.png *.gif *.jpg *.jpeg *.svg
    recursive-include drag_and_drop_v2/public/js *.js
    recursive-include drag_and_drop_v2/templates *.html *.underscore
    recursive-include drag_and_drop_v2/translations *.po *.mo
    recursive-include drag_and_drop_v2/locale *.po *.mo
    ```
    However, using `package_data` seems to be more user-friendly than this.
1. The regexp from https://github.com/openedx/xblock-drag-and-drop-v2/pull/310 was detecting `bleach` instead of `bleach[css]`.

## Testing instructions
1. Run `make piptools`.
2. Run `python setup.py sdist bdist_wheel`.
3. In bash, run `shopt -s globstar && for i in css html js png mo po py; do ls build/**/*.$i > /dev/null; done`. This command should not print anything.