### PR TITLE
feat!: use `replace_urls` service instead of `runtime` property [BD-13]

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,13 @@
 Drag and Drop XBlock changelog
 ==============================
 
+Version 3.2.0 (2023-04-20)
+---------------------------
+
+* Use the `replace_urls` service instead of a runtime property.
+
+  BREAKING CHANGE: This version is no longer compatible with Maple. 
+
 Version 3.1.3 (2023-04-15)
 --------------------------
 

--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,4 +1,4 @@
 """ Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock
 
-__version__ = "3.1.3"
+__version__ = "3.2.0"

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -657,16 +657,8 @@ class DragAndDropBlock(
         if explanation := (self.data.get('explanation') or '').strip():
             if replace_urls_service := self.runtime.service(self, 'replace_urls'):
                 explanation = replace_urls_service.replace_urls(explanation)
-
-            # pylint: disable=fixme
-            # TODO: No longer needed after Maple.
             else:
-                try:
-                    explanation = self.runtime.replace_urls(explanation)
-                    explanation = self.runtime.replace_course_urls(explanation)
-                    explanation = self.runtime.replace_jump_to_id_urls(explanation)
-                except (TypeError, AttributeError):
-                    logger.debug('Unable to perform URL substitution on the explanation: %s', explanation)
+                logger.debug('Unable to perform URL substitution on the explanation: %s', explanation)
 
             answer['explanation'] = sanitize_html(explanation)
         return answer
@@ -1056,8 +1048,8 @@ class DragAndDropBlock(
         This method is unfortunately a bit hackish since XBlock does not provide a low-level API
         for this.
         """
-        if hasattr(self.runtime, 'replace_urls'):
-            url = self.runtime.replace_urls(u'"{}"'.format(url))[1:-1]
+        if replace_urls_service := self.runtime.service(self, 'replace_urls'):
+            url = replace_urls_service.replace_urls(f'"{url}"')[1:-1]
         elif hasattr(self.runtime, 'course_id'):
             # edX Studio uses a different runtime for 'studio_view' than 'student_view',
             # and the 'studio_view' runtime doesn't provide the replace_urls API.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,6 +31,12 @@ def make_block():
     field_data = KvsFieldData(key_store)
     runtime = WorkbenchRuntime()
     runtime.course_id = "dummy_course_id"
+    # noinspection PyProtectedMember
+    runtime._services['replace_urls'] = Mock(  # pylint: disable=protected-access
+        replace_urls=lambda html, static_replace_only=False: re.sub(
+            r'"/static/([^"]*)"', r'"/course/test-course/assets/\1"', html
+        )
+    )
     def_id = runtime.id_generator.create_definition(block_type)
     usage_id = runtime.id_generator.create_usage(def_id)
     scope_ids = ScopeIds('user', block_type, def_id, usage_id)
@@ -59,11 +65,6 @@ class TestCaseMixin(object):
         self.apply_patch(
             'workbench.runtime.WorkbenchRuntime.local_resource_url',
             lambda _, _block, path: '/expanded/url/to/drag_and_drop_v2/' + path
-        )
-        self.apply_patch(
-            'workbench.runtime.WorkbenchRuntime.replace_urls',
-            lambda _, html: re.sub(r'"/static/([^"]*)"', r'"/course/test-course/assets/\1"', html),
-            create=True,
         )
         self.apply_patch(
             'drag_and_drop_v2.drag_and_drop_v2.get_grading_ignore_decoys_waffle_flag',


### PR DESCRIPTION
## Description

BREAKING CHANGE: This breaks Maple compatibility.

Using the property of `runtime` is deprecated. It also breaks Block Structures when the ModuleSystem is unified with DescriptorSystem.

## Supporting information

Related PR: https://github.com/openedx/edx-platform/pull/31472

## Testing instructions (optional)

1. Create a course with two DnDv2 XBlocks and complete the first one.
2. Replace the `block_id` and run the following snippet:
```python
from lms.djangoapps.course_blocks.api import get_course_blocks
from opaque_keys.edx.locator import BlockUsageLocator

u = User.objects.get(username='edx')
key = BlockUsageLocator.from_string('block_id')
block_data = get_course_blocks(u, key)
```
3. Visit the `/dashboard`. This will trigger the code to find the resume URL and attempt to re-generate Block Structures.

## Deadline

Before https://github.com/openedx/edx-platform/pull/31472.