### PR TITLE
chore: release new version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@ Drag and Drop XBlock changelog
 Unreleased
 ---------------------------
 
+Version 3.2.1 (2023-10-12)
+---------------------------
+
+* Added support for Django 4.2
 * The command `make extract_translations` now uses `msgcat` instead of `tail` to combine `djangojs-partial.po` into `django.po`. This is to avoid the possibility of having message compilation failure because of duplicate strings (strings shared between both files)
 
 

--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,4 +1,4 @@
 """ Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock
 
-__version__ = "3.2.0"
+__version__ = "3.2.1"

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,13 @@ setup(
     description='XBlock - Drag-and-Drop v2',
     long_description=README + '\n\n' + CHANGELOG,
     long_description_content_type='text/markdown',
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.8',
+        'Framework :: Django',
+        'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.2',
+    ],
     url='https://github.com/openedx/xblock-drag-and-drop-v2',
     install_requires=load_requirements('requirements/base.in'),
     entry_points={


### PR DESCRIPTION
## Description
- Django 4.2 support was added in the PR https://github.com/openedx/xblock-drag-and-drop-v2/pull/334 but a new version wasn't released with Django42 support.
- Bumped the package version to (`3.2.1`) to release a new version on `PyPI`.