### PR TITLE
fix: Safari focus when there are no draggables left

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@ Drag and Drop XBlock changelog
 Unreleased
 ---------------------------
 
+Version 3.2.2 (2023-10-19)
+---------------------------
+
+* Fix Safari focus when there are no draggables left.
+
 Version 3.2.1 (2023-10-12)
 ---------------------------
 

--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,4 +1,4 @@
 """ Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock
 
-__version__ = "3.2.1"
+__version__ = "3.2.2"

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1310,7 +1310,14 @@ function DragAndDropBlock(runtime, element, configuration) {
     };
 
     var focusFirstDraggable = function() {
-        $root.find('.item-bank .option').first().focus();
+        var draggables = $root.find('.item-bank .option[draggable=true]').toArray();
+        if (draggables.length){
+            draggables[0].focus();
+        }
+        else {
+            // In case there are no draggable options, we default focus to the first zone.
+            $root.find('.target .zone').first().focus();
+        }
     };
 
     var focusItemFeedbackPopup = function() {


### PR DESCRIPTION
## Description

This PR addresses an accessibility issue that has been observed only with Safari when relying solely on the keyboard. 

The problem boils down to losing focus after the last correct drop happens and there are no more draggable items left in the bank. 

The focus is "trapped" within  `.close-feedback-popup-button`  which loses visibility after it's closed and the [focusFirstDraggable ](https://github.com/openedx/xblock-drag-and-drop-v2/blob/f3318840cb14eed4ac0aa6fd231482c39b0e92e6/drag_and_drop_v2/public/js/drag_and_drop.js#L1312), which is subsequently called, tries to shift focus to the first option, which happens to be an invisible item placeholder that is not focusable because it has no tabindex. 

Clicking **Tab**, **Shift+Tab**, or **ESC** has no effect in Safari. With Chrome or Firefox, however, the focus is able to leave the hidden button and jump to the first Zone. 

This PR  adds a check to ensure the presence of draggable items and otherwise defaults focus to the first Zone in `focusFirstDraggable`.


## Testing instructions

1.  Launch LMS & CMS in devstack.
2.  Connect to your CMS <ins> **_using Safari_** </ins>
3.  Create a drag-and-drop problem. There is no need to edit. The default one (triangle) will do.
4.  Try to solve the problem correctly using only the keyboard.
5.  After dropping the last item and closing the feedback popup, focus should be lost

 Please check the following video. I increased the outlines' width for better clarity.


https://github.com/openedx/xblock-drag-and-drop-v2/assets/28169169/ae34c4dc-def9-47ff-b780-108376454725
