### PR TITLE
build: Remove un-necessary constraints.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,6 +12,3 @@
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
 
 pylint==2.4.2
-
-selenium==2.53.6
-bok-choy==0.7.1


### PR DESCRIPTION
These constraints are no-longer needed because we don't depend on either
of these packages.
