### PR TITLE
feat: use XBlockI18NService js translations | FC-0012

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@ Drag and Drop XBlock changelog
 Unreleased
 ---------------------------
 
+Version 3.4.0 (2024-01-15)
+---------------------------
+
+* XBlockI18NService js translations support
+
 Version 3.3.0 (2023-10-24)
 ---------------------------
 

--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,4 +1,4 @@
 """ Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"


### PR DESCRIPTION
## Implement OEP-58 JavaScript translations

 - Proposal: https://github.com/openedx/edx-platform/pull/33166
 - Supporting platform pull request: https://github.com/openedx/edx-platform/pull/33698

## Testing

Tested with results posted https://github.com/openedx/edx-platform/pull/33698#issue-1988538631

## Reference

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
