### PR TITLE
feat: add content tag serialization/deserialization [FC-0049]

### DIFF
--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,4 +1,4 @@
 """ Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"

--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -252,6 +252,9 @@ class DragAndDropBlock(
 
     block_settings_key = 'drag-and-drop-v2'
 
+    xml_attributes = Dict(help="Map of unhandled xml attributes, used only for storage between import and export",
+                          default={}, scope=Scope.settings)
+
     @property
     def score(self):
         """
@@ -1387,3 +1390,30 @@ class DragAndDropBlock(
         xblock_body["content_type"] = "Drag and Drop"
 
         return xblock_body
+
+    def add_xml_to_node(self, node):
+        """
+        Serialize the XBlock to XML for exporting.
+        """
+        super().add_xml_to_node(node)
+
+        # Serialize and add tag data if any
+        if hasattr(self, 'add_tags_to_node') and callable(self.add_tags_to_node):  # pylint: disable=no-member
+            # This comes from TaggedBlockMixin
+            self.add_tags_to_node(node)  # pylint: disable=no-member
+
+    @classmethod
+    def parse_xml(cls, node, runtime, keys, id_generator):
+        """Instantiate XBlock object from runtime XML definition.
+
+        Inherited by XBlock core.
+        """
+        breakpoint()
+        block = super().parse_xml(node, runtime, keys, id_generator)
+
+        # Deserialize and add tag data info to block if any
+        if hasattr(block, 'read_tags_from_node') and callable(block.read_tags_from_node):  # pylint: disable=no-member
+            # This comes from TaggedBlockMixin
+            block.read_tags_from_node(node)  # pylint: disable=no-member
+
+        return block


### PR DESCRIPTION
## Description

This PR adds support to serialize/deserialize tag info from the block XML, adding it to the new `xml_attributes` property. This is used to allow pasting DragAndDrop components with their applied tags.

## More Information
- Part of: https://github.com/openedx/modular-learning/issues/180

## Testing instructions
- Please ensure that the tests cover the expected behavior
- Follow the instructions at https://github.com/openedx/edx-platform/pull/34270 and check if you can copy/paste a DragAndDrop with tags and ensure that the tags are copied correctly
