### PR TITLE
fix: set go to beginning button to hidden

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@ Unreleased
 
 * Adjust code styling for newer pylint versions.
 
+Version 4.0.3 (2024-05-23)
+---------------------------
+
+* Set go-to-beginning button to hidden for Screen Readers
+
 Version 4.0.2 (2024-04-24)
 --------------------------
 

--- a/drag_and_drop_v2/__init__.py
+++ b/drag_and_drop_v2/__init__.py
@@ -1,4 +1,4 @@
 """ Drag and Drop v2 XBlock """
 from .drag_and_drop_v2 import DragAndDropBlock
 
-__version__ = "4.0.2"
+__version__ = "4.0.3"

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -815,7 +815,6 @@
     color: #000000;
 }
 
-
 /* Prevent mobile browsers from emulating hover effects on item tap, which can be confusing. */
 @media (hover: none) {
     .xblock--drag-and-drop .drag-container .option[draggable='true']:hover {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -459,7 +459,7 @@ function DragAndDropTemplates(configuration) {
             go_to_beginning_button_class += ' sr';
         }
         return(
-            h("div.problem-action-buttons-wrapper", {attributes: {'role': 'group', 'aria-label': gettext('Actions')}}, [
+            h("div.problem-action-buttons-wrapper", {}, [
                 sidebarButtonTemplate(
                     go_to_beginning_button_class,
                     "fa-arrow-up",

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1052,6 +1052,16 @@ function DragAndDropBlock(runtime, element, configuration) {
         $root.find('.keyboard-help-dialog .modal-dismiss-button').focus();
     };
 
+    var focusSuccessFeedback = function() {
+        var $feedback = $element.find('.final');
+        if ($feedback.is(':visible')) {
+            $feedback.attr('tabindex', '-1');
+            $feedback.focus();
+            return true;
+        };
+        return false;
+    }
+
     var showKeyboardHelp = function(evt) {
         var focusId = document.activeElement;
         evt.preventDefault();
@@ -1829,7 +1839,7 @@ function DragAndDropBlock(runtime, element, configuration) {
         applyState();
 
         if (manually_closed) {
-            focusFirstDraggable();
+            focusSuccessFeedback() || focusFirstDraggable();
         }
     };
 
@@ -1903,7 +1913,7 @@ function DragAndDropBlock(runtime, element, configuration) {
         }).always(function() {
             state.submit_spinner = false;
             applyState();
-            focusItemFeedbackPopup() || focusFirstDraggable();
+            focusItemFeedbackPopup() || focusSuccessFeedback() || focusFirstDraggable();
         });
     };
 

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -318,7 +318,7 @@ function DragAndDropTemplates(configuration) {
 
         return (
             h('div.feedback', {
-                attributes: {'role': 'group', 'aria-label': gettext('Feedback')},
+                attributes: {'role': 'group', 'aria-label': gettext('Feedback'), 'aria-live': 'polite'},
                 style: { display: feedback_display }
             }, [
                 h('div.feedback-content',[
@@ -424,7 +424,7 @@ function DragAndDropTemplates(configuration) {
             iconClass = 'fa-spin fa-spinner';
         }
         return (
-            h('span.problem-action-button-wrapper', {}, [
+            h('span.problem-action-button-wrapper', {attributes: {"aria-hidden": options.disabled || false}}, [
                 h(
                     'button.problem-action-btn.btn-default.btn-small',
                     {
@@ -456,7 +456,7 @@ function DragAndDropTemplates(configuration) {
         }
         var go_to_beginning_button_class = 'go-to-beginning-button';
         if (!ctx.show_go_to_beginning_button) {
-            go_to_beginning_button_class += ' hidden';
+            go_to_beginning_button_class += ' sr';
         }
         return(
             h("div.problem-action-buttons-wrapper", {attributes: {'role': 'group', 'aria-label': gettext('Actions')}}, [
@@ -1330,6 +1330,17 @@ function DragAndDropBlock(runtime, element, configuration) {
         }
     };
 
+    var focusSubmitButton = function() {
+        var submitButton = $root.find('.btn-brand.submit').toArray();
+        if (submitButton.length){
+            submitButton[0].focus();
+        }
+        else {
+            // In case there are is no submit button, we default focus to the first zone.
+            $root.find('.target .zone').first().focus();
+        }
+    };
+
     var focusItemFeedbackPopup = function() {
         var popup = $root.find('.item-feedback-popup');
         if (popup.length && popup.is(":visible")) {
@@ -1810,8 +1821,11 @@ function DragAndDropBlock(runtime, element, configuration) {
                     // Move focus the the close button of the feedback popup.
                     focusItemFeedbackPopup();
                 } else {
-                    // Next tab press should take us to the "Go to Beginning" button.
-                    state.tab_to_go_to_beginning_button = true;
+                    if ($root.find('.item-bank .option[draggable=true]').length) {
+                        focusFirstDraggable();
+                    } else {
+                        focusSubmitButton();
+                    };
                 }
             })
             .fail(function (data) {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -456,7 +456,7 @@ function DragAndDropTemplates(configuration) {
         }
         var go_to_beginning_button_class = 'go-to-beginning-button';
         if (!ctx.show_go_to_beginning_button) {
-            go_to_beginning_button_class += ' sr';
+            go_to_beginning_button_class += ' hidden';
         }
         return(
             h("div.problem-action-buttons-wrapper", {attributes: {'role': 'group', 'aria-label': gettext('Actions')}}, [


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable. If your linked information must be private (because it has secrets),
clearly label the link as private.
-->

## Description

This PR addresses a few accessibility issues when using the xblock with keyboard and Voice Over controls.

When submitting the problem:
- the go-to-beginning button is still visible for Voice Over controls. This is inconsistent with tab key behaviour, so instead of disabling it, we're setting display: none
- the focus stays in the first draggable item, even though the problem is finished. Instead we're going to focus the feedback paragraph.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

1. Launch LMS & CMS in devstack.
2. Connect to your CMS using Safari
3. Create a drag-and-drop problem. There is no need to edit. The default one (triangle) will do.


### (Non-Assessment)
 
4. Try to solve the problem correctly using only the keyboard.
5. After dropping the last item and closing the feedback popup, focus should be on the feedback text bellow.

### (Assessment)

4. In studio change the problem to be an assessment
5. Try to solve the problem correctly using only the Voice Over keyboard actions.
6. Assert that after dropping each item the focus moves back to the first draggable item
7. After dropping the last item and closing the feedback popup, focus should be on the submit button bellow.
8. Assert that after submitting the problem, the go-to-beginning button is not read by the screen reader.
