### PR TITLE
build: add Django 5.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.11, 3.12]
-        toxenv: [django42, quality, translations]
+        toxenv: [django42, django52, quality, translations]
 
     steps:
     - name: checkout repo

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{311,312}-django{42},quality,translations
+envlist = py{311,312}-django{42,52},quality,translations
 
 [pycodestyle]
 exclude = .git,.tox
@@ -21,6 +21,7 @@ allowlist_externals =
     mkdir
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =
     mkdir -p var


### PR DESCRIPTION
This adds Django 5.2 to the testing pipelines.

Resolves https://github.com/openedx/xblock-drag-and-drop-v2/issues/466