### PR TITLE
fix: load virtualdom and drag and drop js in line

### DIFF
--- a/drag_and_drop_v2/drag_and_drop_v2.py
+++ b/drag_and_drop_v2/drag_and_drop_v2.py
@@ -348,7 +348,7 @@ class DragAndDropBlock(
         for css_url in css_urls:
             fragment.add_css_url(self.runtime.local_resource_url(self, css_url))
         for js_url in js_urls:
-            fragment.add_javascript_url(self.runtime.local_resource_url(self, js_url))
+            fragment.add_javascript(loader.load_unicode(js_url))
 
         statici18n_js_url = self._get_statici18n_js_url()
         if statici18n_js_url:


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable. If your linked information must be private (because it has secrets),
clearly label the link as private.
-->

## Description

When loading the js for virtualdom and drag_and_drop (which depends on virtualdom) from cache, if for some reason the cached version of drag_and_drop was loaded before virtualdom, virtualdom would be undefined and the xblock would fail to load. With these changes the javascript code will be inlined in the html so that guaranteed to  always load in the correct order.

## Supporting information

- Issue: https://github.com/openedx/frontend-app-authoring/issues/1749
- [Private-ref
](https://tasks.opencraft.com/browse/FAL-4191)
## Testing instructions

- Load this PR in a tutor local installation: `tutor mounts add xblock-drag-and-drop-v2`
- In libraries v2:
  * Create a drag and drop element
  * select it and open the preview tab in the right sidebar
  * click on expand on the side bar to load it again
  * assert it loads

## Deadline

asap